### PR TITLE
Adding first p8 elements, NOT DONE

### DIFF
--- a/Exercises/fem/src/fem/element/cnd.py
+++ b/Exercises/fem/src/fem/element/cnd.py
@@ -283,3 +283,65 @@ class CPE4(CPX4):
 
     def history_variables(self) -> list[str]:
         return ["exx", "eyy", "ezz", "exy", "sxx", "syy", "szz", "sxy"]
+
+
+class CPX8(P8, CnD, IsoparametricElement):
+    """
+    Base constant strain quadrilateral element (8 nodes).
+
+    Geometric shape (P8) with continuum material update behavior.
+    """
+
+    gauss_pts = np.array([[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0], [1.0, 1.0]]) / np.sqrt(3.0)
+    gauss_wts = np.array([1.0, 1.0, 1.0, 1.0], dtype=float)
+    edge_gauss_pts = np.array([-1.0 / np.sqrt(3.0), 1.0 / np.sqrt(3.0)], dtype=float)
+    edge_gauss_wts = np.array([1.0, 1.0], dtype=float)
+
+    @property
+    def node_freedom_table(self) -> list[tuple[int, ...]]:
+        return [(Ux, Uy), (Ux, Uy), (Ux, Uy), (Ux, Uy)]
+
+    def pmatrix(self, xi: NDArray) -> NDArray:
+        N = self.shape(xi)
+        P = np.zeros((8, 2))
+        P[0::2, 0] = N
+        P[1::2, 1] = N
+        return P
+
+
+class CPS8(CPX8):
+    """Plane stress constant strain quadrilateral element."""
+
+    ndir = 2
+    nshr = 1
+
+    def bmatrix(self, p: NDArray, xi: NDArray) -> NDArray:
+        dNdx = self.shape_gradient(p, xi)
+        B = np.zeros((3, 8))
+        B[0, 0::2] = dNdx[0]
+        B[1, 1::2] = dNdx[1]
+        B[2, 0::2] = dNdx[1]
+        B[2, 1::2] = dNdx[0]
+        return B
+
+    def history_variables(self) -> list[str]:
+        return ["exx", "eyy", "exy", "sxx", "syy", "sxy"]
+
+
+class CPE8(CPX8):
+    """Plane strain constant strain quadrilateral element."""
+
+    ndir = 3
+    nshr = 1
+
+    def bmatrix(self, p: NDArray, xi: NDArray) -> NDArray:
+        dNdx = self.shape_gradient(p, xi)
+        B = np.zeros((4, 8))
+        B[0, 0::2] = dNdx[0]
+        B[1, 1::2] = dNdx[1]
+        B[3, 0::2] = dNdx[1]
+        B[3, 1::2] = dNdx[0]
+        return B
+
+    def history_variables(self) -> list[str]:
+        return ["exx", "eyy", "ezz", "exy", "sxx", "syy", "szz", "sxy"]

--- a/Exercises/fem/src/fem/element/geom.py
+++ b/Exercises/fem/src/fem/element/geom.py
@@ -136,3 +136,51 @@ class P4(Pn):
         d += (xp[2] * yp[3] - xp[3] * yp[2]) + (xp[3] * yp[0] - xp[0] * yp[3])
         assert d > 0
         return d / 2.0
+
+
+class P8(Pn):
+    """Linear 8-node quad
+
+    Notes
+    -----
+    Node and element face numbering
+
+               [2]
+            3-------2
+            |       |
+       [3]  |       | [1]
+            |       |
+            0-------1
+               [0]
+
+    """
+
+    family = "QUAD8"
+    edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=int)
+    ref_coords = np.array([[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]], dtype=float)
+
+    def shape(self, xi: NDArray) -> NDArray:
+        s, t = xi
+        a = np.array(
+            [
+                (1.0 - s) * (1.0 - t),
+                (1.0 + s) * (1.0 - t),
+                (1.0 + s) * (1.0 + t),
+                (1.0 - s) * (1.0 + t),
+            ]
+        )
+        return a / 4.0
+
+    def shapegrad(self, xi):
+        s, t = xi
+        a = np.array(
+            [[-1.0 + t, 1.0 - t, 1.0 + t, -1.0 - t], [-1.0 + s, -1.0 - s, 1.0 + s, 1.0 - s]]
+        )
+        return a / 4.0
+
+    def area(self, p: NDArray) -> float:
+        xp, yp = p[:, 0], p[:, 1]
+        d = (xp[0] * yp[1] - xp[1] * yp[0]) + (xp[1] * yp[2] - xp[2] * yp[1])
+        d += (xp[2] * yp[3] - xp[3] * yp[2]) + (xp[3] * yp[0] - xp[0] * yp[3])
+        assert d > 0
+        return d / 2.0


### PR DESCRIPTION
## Summary by Sourcery

Introduce 8-node quadrilateral geometry and corresponding constant-strain continuum elements for plane stress and plane strain analyses.

New Features:
- Add P8 8-node quadrilateral geometric element with shape functions, gradients, and area computation.
- Add CPX8 base constant-strain quadrilateral continuum element using P8 geometry and Gauss integration setup.
- Add CPS8 plane-stress and CPE8 plane-strain constant-strain 8-node quadrilateral elements with appropriate B-matrices and history variables.